### PR TITLE
Improving UX on URP and HDRP projects

### DIFF
--- a/Editor/404.404-gen-unity-plugin.Editor.asmdef
+++ b/Editor/404.404-gen-unity-plugin.Editor.asmdef
@@ -24,6 +24,11 @@
             "name": "com.unity.render-pipelines.high-definition",
             "expression": "",
             "define": "GS_ENABLE_HDRP"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "",
+            "define": "GS_ENABLE_URP"
         }
     ],
     "noEngineReferences": false

--- a/Editor/404.404-gen-unity-plugin.Editor.asmdef
+++ b/Editor/404.404-gen-unity-plugin.Editor.asmdef
@@ -1,4 +1,4 @@
-﻿{
+{
     "name": "404.404-gen-unity-plugin",
     "rootNamespace": "",
     "references": [
@@ -18,6 +18,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "",
+            "define": "GS_ENABLE_HDRP"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Editor/404.404-gen-unity-plugin.Editor.asmdef
+++ b/Editor/404.404-gen-unity-plugin.Editor.asmdef
@@ -8,7 +8,8 @@
         "Unity.Mathematics",
         "Unity.Collections.Editor",
         "Unity.Collections",
-        "Unity.RenderPipelines.HighDefinition.Runtime"
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Unity.RenderPipelines.Universal.Runtime"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/404.404-gen-unity-plugin.Editor.asmdef
+++ b/Editor/404.404-gen-unity-plugin.Editor.asmdef
@@ -7,7 +7,8 @@
         "Unity.Burst",
         "Unity.Mathematics",
         "Unity.Collections.Editor",
-        "Unity.Collections"
+        "Unity.Collections",
+        "Unity.RenderPipelines.HighDefinition.Runtime"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/404GenTool.cs
+++ b/Editor/404GenTool.cs
@@ -11,6 +11,10 @@ using System.Net.WebSockets;
 using Newtonsoft.Json;
 using GaussianSplatting.Runtime;
 
+#if GS_ENABLE_HDRP
+using UnityEngine.Rendering.HighDefinition;
+#endif
+
 namespace GaussianSplatting.Editor
 {
     public class WebSocketEditorWindow : EditorWindow
@@ -51,8 +55,10 @@ namespace GaussianSplatting.Editor
                 AssetDatabase.CreateAsset(windowData, WebSocketEditorWindowData.EditorWindowDataPath);
                 AssetDatabase.SaveAssets();
             }
+
+            EditorApplication.hierarchyChanged += RenderingSetupCheck;
+            RenderingSetupCheck();
         }
-        
 
         private void OnGUI()
         {
@@ -62,7 +68,7 @@ namespace GaussianSplatting.Editor
             DrawSettings();
             DrawPromptInput();
             GUILayout.Space(20);
-            
+            DrawRenderingSetup();
             DrawPromptsTableItems();
             ProcessPromptItems();
         }
@@ -160,7 +166,6 @@ namespace GaussianSplatting.Editor
             // Initialize the GUIStyle for prompt text label
             m_promptLabelStyle ??= new GUIStyle(GUI.skin.label)
             {
-                //normal = { textColor = shockingOrangeColor },
                 fontStyle = FontStyle.Bold,
                 fontSize = 16,
                 padding = new RectOffset(0,0,0,0)
@@ -180,13 +185,11 @@ namespace GaussianSplatting.Editor
             {
                 normal = { background = darkRowTexture },
                 fixedHeight = 60,
-                //padding = new RectOffset(12, 12, 4, 8)
             };
             m_rowLightStyle ??= new GUIStyle(GUI.skin.box)
             {
                 normal = { background = lightRowTexture },
                 fixedHeight = 60,
-                //padding = new RectOffset(12, 12, 4, 8)
             };
 
             m_timeLabelStyle ??= new GUIStyle(GUI.skin.label)
@@ -322,6 +325,7 @@ namespace GaussianSplatting.Editor
             GUI.enabled = generateButtonEnabled;
             if (GUILayout.Button("Generate", m_generateButtonStyle))
             {
+                RenderingSetupCheck();
                 windowData.EnqueuePrompt(m_inputText);
                 m_inputText = "";
                 windowData.promptsScrollPosition = Vector2.zero;
@@ -658,6 +662,91 @@ namespace GaussianSplatting.Editor
             }
         }
 
+        private bool m_showRenderingSetup;
+        
+        private void RenderingSetupCheck()
+        {
+#if GS_ENABLE_HDRP
+            var effectInstance = GameObject.Find("GaussianSplatEffect");
+            if (effectInstance != null)
+            {
+                m_showRenderingSetup = false;
+                return;
+            }
+            
+            CustomPassVolume[] volumes = FindObjectsOfType<CustomPassVolume>();
+
+            
+            bool gaussianSplatHDRPPassFound = false;
+            foreach (var volume in volumes)
+            {
+                if (volume && volume.customPasses != null)
+                {
+                    if (volume.customPasses.Any(customPass => customPass is GaussianSplatHDRPPass))
+                    {
+                        gaussianSplatHDRPPassFound = true;
+                        break;
+                    }
+                }
+            }
+
+            if (gaussianSplatHDRPPassFound)
+            {
+                m_showRenderingSetup = false;
+                return;
+            }
+            
+            m_showRenderingSetup = true;
+#endif
+        }
+        
+        private void DrawRenderingSetup()
+        {
+            if (!m_showRenderingSetup) return;
+#if GS_ENABLE_URP
+            GUILayout.Label("URP");
+#elif GS_ENABLE_HDRP
+            EditorGUILayout.HelpBox(
+                    "To add Gaussian splats to the HDRP rendering process, a CustomPassVolume must be present in the scene. " +
+                    "Click here to add a preconfigured CustomPassVolume by instantiating a prefab named 'GaussianSplatEffect' from the Resources folder.",
+                    MessageType.Warning);
+
+            if (GUILayout.Button("Add HDRP custom pass"))
+            {
+                AddGaussianSplatEffect();
+            }
+#else
+            GUILayout.Label("Built in renderer");
+#endif
+        }
+        
+        private void AddGaussianSplatEffect()
+        {
+            // Load the prefab from the Resources folder
+            GameObject prefab = Resources.Load<GameObject>("GaussianSplatEffect");
+
+            if (prefab == null)
+            {
+                Debug.LogError("GaussianSplatEffect prefab not found in Resources folder. Please ensure the prefab is correctly placed in a 'Resources' folder.");
+                return;
+            }
+
+            // Instantiate the prefab into the scene
+            GameObject instance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+
+            if (instance != null)
+            {
+                Undo.RegisterCreatedObjectUndo(instance, "Add Gaussian Splat Effect");
+                Selection.activeGameObject = instance;
+
+                Debug.Log("Gaussian Splat Effect added to the scene.");
+            }
+            else
+            {
+                Debug.LogError("Failed to instantiate GaussianSplatEffect prefab.");
+            }
+        }
+
         // Sends authentication data (API key) to the WebSocket server
         private async Task SendAuthData()
         {
@@ -797,6 +886,7 @@ namespace GaussianSplatting.Editor
         private void OnDestroy()
         {
             CloseWebSocket();
+            EditorApplication.hierarchyChanged -= RenderingSetupCheck;
         }
 
         private async void CloseWebSocket()

--- a/Runtime/EnqueueURPPass.cs
+++ b/Runtime/EnqueueURPPass.cs
@@ -1,0 +1,43 @@
+﻿using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace GaussianSplatting.Runtime
+{
+    [ExecuteInEditMode]
+    public class EnqueueURPPass : MonoBehaviour
+    {
+        GaussianSplatURPFeature.GSRenderPass m_Pass;
+        private void OnEnable()
+        {
+            m_Pass = new GaussianSplatURPFeature.GSRenderPass
+            {
+                renderPassEvent = RenderPassEvent.BeforeRenderingTransparents
+            };
+            // Subscribe the OnBeginCamera method to the beginCameraRendering event.
+            RenderPipelineManager.beginCameraRendering += OnBeginCamera;
+        }
+
+        private void OnBeginCamera(ScriptableRenderContext context, Camera cam)
+        {
+            //pre cull
+            var system = GaussianSplatRenderSystem.instance;
+            if (!system.GatherSplatsForCamera(cam))
+                return;
+
+            CommandBuffer cmb = system.InitialClearCmdBuffer(cam);
+            m_Pass.m_Cmb = cmb;
+            
+            // Use the EnqueuePass method to inject a custom render pass
+            var scriptableRenderer = cam.GetUniversalAdditionalCameraData().scriptableRenderer;
+            m_Pass.m_Renderer = scriptableRenderer;
+            scriptableRenderer.EnqueuePass(m_Pass);
+        }
+        
+        private void OnDisable()
+        {
+            RenderPipelineManager.beginCameraRendering -= OnBeginCamera;
+            m_Pass?.Dispose();
+        }
+    }
+}

--- a/Runtime/EnqueueURPPass.cs.meta
+++ b/Runtime/EnqueueURPPass.cs.meta
@@ -1,0 +1,11 @@
+﻿fileFormatVersion: 2
+guid: 2c4c304f0af564c43a3ac2d4f4651ba1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/GaussianSplatHDRPPass.cs
+++ b/Runtime/GaussianSplatHDRPPass.cs
@@ -10,7 +10,7 @@ namespace GaussianSplatting.Runtime
 {
     // Note: I have no idea what is the proper usage of CustomPass.
     // Code below "seems to work" but I'm just fumbling along, without understanding any of it.
-    class GaussianSplatHDRPPass : CustomPass
+    public class GaussianSplatHDRPPass : CustomPass
     {
         RTHandle m_RenderTarget;
 

--- a/Runtime/GaussianSplatURPFeature.cs
+++ b/Runtime/GaussianSplatURPFeature.cs
@@ -13,9 +13,9 @@ namespace GaussianSplatting.Runtime
     // without understanding any of it.
     //
     // ReSharper disable once InconsistentNaming
-    class GaussianSplatURPFeature : ScriptableRendererFeature
+    public class GaussianSplatURPFeature : ScriptableRendererFeature
     {
-        class GSRenderPass : ScriptableRenderPass
+        public class GSRenderPass : ScriptableRenderPass
         {
             RTHandle m_RenderTarget;
             internal ScriptableRenderer m_Renderer = null;

--- a/Runtime/Resources.meta
+++ b/Runtime/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2dba16abd479d3d49ba29c619130afad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Resources/GaussianSplatEffect.prefab
+++ b/Runtime/Resources/GaussianSplatEffect.prefab
@@ -1,0 +1,67 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1569842993472757071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 516929855546410455}
+  - component: {fileID: 2389493450546278637}
+  m_Layer: 0
+  m_Name: GaussianSplatEffect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &516929855546410455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569842993472757071}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2389493450546278637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569842993472757071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26d6499a6bd256e47b859377446493a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 1
+  fadeRadius: 0
+  priority: 0
+  customPasses:
+  - rid: 6019242806452944896
+  injectionPoint: 3
+  m_TargetCamera: {fileID: 0}
+  useTargetCamera: 0
+  references:
+    version: 2
+    RefIds:
+    - rid: 6019242806452944896
+      type: {class: GaussianSplatHDRPPass, ns: GaussianSplatting.Runtime, asm: GaussianSplatting}
+      data:
+        m_Name: Custom Pass
+        enabled: 1
+        targetColorBuffer: 0
+        targetDepthBuffer: 0
+        clearFlags: 0
+        passFoldout: 0
+        m_Version: 0

--- a/Runtime/Resources/GaussianSplatEffect.prefab.meta
+++ b/Runtime/Resources/GaussianSplatEffect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a370e0ead5d83d046a6e7017bc9feead
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Resources/GaussianSplatURPPass.prefab
+++ b/Runtime/Resources/GaussianSplatURPPass.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5566869170673665784
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3322081541627331764}
+  - component: {fileID: 6729425250103886286}
+  m_Layer: 0
+  m_Name: GaussianSplatURPPass
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3322081541627331764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5566869170673665784}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6729425250103886286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5566869170673665784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c4c304f0af564c43a3ac2d4f4651ba1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runtime/Resources/GaussianSplatURPPass.prefab.meta
+++ b/Runtime/Resources/GaussianSplatURPPass.prefab.meta
@@ -1,0 +1,7 @@
+﻿fileFormatVersion: 2
+guid: b1063b95fa25d05498a21912aa4aa648
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This will improve the users' experience with HDRP project as it will remove the need to manually add to the scene Custom Pass Volume component with GaussianSplatHDRPPass to inject Gaussians to the HDRP rendering process.
The 404-Gen dialog will show warning if such Custom Pass Volume is not present and provide a quick way to add it by instantiating a predefined prefab [Runtime/Resources/GaussianSplatEffect.prefab](https://github.com/404-Repo/404-gen-unity-plugin/compare/dev...feature/rendering-setup?expand=1#diff-8a1119e094f4eaa9ade116e9611831016cf23aee8a1fa2f3b6b193db9b1fede3)

![HDRPCustomPassDialog](https://github.com/user-attachments/assets/0f57162d-23c4-4c74-a174-2e5015dd24bb)
