### PR TITLE
change color from Prompt input text area

### DIFF
--- a/Editor/404GenTool.cs
+++ b/Editor/404GenTool.cs
@@ -148,10 +148,7 @@ namespace GaussianSplatting.Editor
                 fontStyle = FontStyle.Bold,
                 richText = true,
                 padding = new RectOffset(10, 10, 10, 10),
-                wordWrap = true,
-                normal = {textColor = shockingOrangeColor},
-                active = {textColor = shockingOrangeColor},
-                focused = {textColor = shockingOrangeColor}
+                wordWrap = true
             };
             
             m_generateButtonStyle ??= new GUIStyle(GUI.skin.button)


### PR DESCRIPTION
Removes shocking orange color from Prompt text area label

![image](https://github.com/user-attachments/assets/74696a30-db0b-441c-b4c7-70884c2329be)

